### PR TITLE
Removed quotes in getItemsetup

### DIFF
--- a/pyControl4/director.py
+++ b/pyControl4/director.py
@@ -133,7 +133,7 @@ class C4Director:
             `item_id` - The Control4 item ID.
         """
         return await self.sendPostRequest(
-            "/api/v1/items/{}/commands".format(item_id), "GET_SETUP", "{}", False
+            "/api/v1/items/{}/commands".format(item_id), "GET_SETUP", {}, False
         )
 
     async def getItemVariables(self, item_id):


### PR DESCRIPTION
This is causing components to failed in the hass-control4 setup, eg: https://github.com/lawtancool/hass-control4/issues/23
