### PR TITLE
feature: support python 3.11+  async_timeout module

### DIFF
--- a/pyControl4/account.py
+++ b/pyControl4/account.py
@@ -4,6 +4,7 @@ controller info, and retrieves a bearer token for connecting to a Control4 Direc
 
 import aiohttp
 import async_timeout
+from .compat import timeout_ctx
 import json
 import logging
 import datetime
@@ -64,14 +65,14 @@ class C4Account:
         }
         if self.session is None:
             async with aiohttp.ClientSession() as session:
-                with async_timeout.timeout(10):
+                async with timeout_ctx(10):
                     async with session.post(
                         AUTHENTICATION_ENDPOINT, json=dataDictionary
                     ) as resp:
                         await checkResponseForError(await resp.text())
                         return await resp.text()
         else:
-            with async_timeout.timeout(10):
+            async with timeout_ctx(10):
                 async with self.session.post(
                     AUTHENTICATION_ENDPOINT, json=dataDictionary
                 ) as resp:
@@ -94,12 +95,12 @@ class C4Account:
             raise
         if self.session is None:
             async with aiohttp.ClientSession() as session:
-                with async_timeout.timeout(10):
+                async with timeout_ctx(10):
                     async with session.get(uri, headers=headers) as resp:
                         await checkResponseForError(await resp.text())
                         return await resp.text()
         else:
-            with async_timeout.timeout(10):
+            async with timeout_ctx(10):
                 async with self.session.get(uri, headers=headers) as resp:
                     await checkResponseForError(await resp.text())
                     return await resp.text()
@@ -125,7 +126,7 @@ class C4Account:
         }
         if self.session is None:
             async with aiohttp.ClientSession() as session:
-                with async_timeout.timeout(10):
+                async with timeout_ctx(10):
                     async with session.post(
                         CONTROLLER_AUTHORIZATION_ENDPOINT,
                         headers=headers,
@@ -134,7 +135,7 @@ class C4Account:
                         await checkResponseForError(await resp.text())
                         return await resp.text()
         else:
-            with async_timeout.timeout(10):
+            async with timeout_ctx(10):
                 async with self.session.post(
                     CONTROLLER_AUTHORIZATION_ENDPOINT,
                     headers=headers,

--- a/pyControl4/compat.py
+++ b/pyControl4/compat.py
@@ -1,0 +1,41 @@
+"""Compatibility utilities for differing dependency versions.
+
+Currently provides an async-timeout wrapper that works with both
+async-timeout >= 4.x (async context manager) and < 4.x (sync context manager).
+"""
+
+import typing as _t
+
+try:
+    import async_timeout as _async_timeout
+except Exception:  # pragma: no cover
+    _async_timeout = None  # type: ignore
+
+
+class _AsyncifyContextManager:
+    def __init__(self, sync_cm: _t.Any) -> None:
+        self._sync_cm = sync_cm
+
+    async def __aenter__(self) -> _t.Any:
+        return self._sync_cm.__enter__()
+
+    async def __aexit__(self, exc_type, exc, tb) -> _t.Optional[bool]:
+        return self._sync_cm.__exit__(exc_type, exc, tb)
+
+
+def timeout_ctx(seconds: float):
+    """Return an async-compatible context manager for timeouts.
+
+    Works whether async-timeout returns an async or sync context manager.
+    """
+    if _async_timeout is None:
+        raise RuntimeError("async_timeout is required for timeout_ctx")
+
+    cm = _async_timeout.timeout(seconds)
+    # If async context manager is supported, use directly
+    if hasattr(cm, "__aenter__") and hasattr(cm, "__aexit__"):
+        return cm
+    # Fallback: wrap sync context manager for async `async with` usage
+    return _AsyncifyContextManager(cm)
+
+

--- a/pyControl4/director.py
+++ b/pyControl4/director.py
@@ -4,6 +4,7 @@ getting details about items on the Director.
 
 import aiohttp
 import async_timeout
+from .compat import timeout_ctx
 import json
 
 from .error_handling import checkResponseForError
@@ -50,14 +51,14 @@ class C4Director:
             async with aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(verify_ssl=False)
             ) as session:
-                with async_timeout.timeout(10):
+                async with timeout_ctx(10):
                     async with session.get(
                         self.base_url + uri, headers=self.headers
                     ) as resp:
                         await checkResponseForError(await resp.text())
                         return await resp.text()
         else:
-            with async_timeout.timeout(10):
+            async with timeout_ctx(10):
                 async with self.session.get(
                     self.base_url + uri, headers=self.headers
                 ) as resp:
@@ -86,14 +87,14 @@ class C4Director:
             async with aiohttp.ClientSession(
                 connector=aiohttp.TCPConnector(verify_ssl=False)
             ) as session:
-                with async_timeout.timeout(10):
+                async with timeout_ctx(10):
                     async with session.post(
                         self.base_url + uri, headers=self.headers, json=dataDictionary
                     ) as resp:
                         await checkResponseForError(await resp.text())
                         return await resp.text()
         else:
-            with async_timeout.timeout(10):
+            async with timeout_ctx(10):
                 async with self.session.post(
                     self.base_url + uri, headers=self.headers, json=dataDictionary
                 ) as resp:

--- a/pyControl4/websocket.py
+++ b/pyControl4/websocket.py
@@ -2,6 +2,7 @@
 
 import aiohttp
 import async_timeout
+from .compat import timeout_ctx
 import socketio_v4 as socketio
 import logging
 
@@ -60,7 +61,7 @@ class _C4DirectorNamespace(socketio.AsyncClientNamespace):
                 async with aiohttp.ClientSession(
                     connector=aiohttp.TCPConnector(verify_ssl=False)
                 ) as session:
-                    with async_timeout.timeout(10):
+                    async with timeout_ctx(10):
                         async with session.get(
                             self.url + self.uri,
                             params={"JWT": self.token, "SubscriptionClient": clientId},
@@ -71,7 +72,7 @@ class _C4DirectorNamespace(socketio.AsyncClientNamespace):
                             self.subscriptionId = data["subscriptionId"]
                             await self.emit("startSubscription", self.subscriptionId)
             else:
-                with async_timeout.timeout(10):
+                async with timeout_ctx(10):
                     async with self.session.get(
                         self.url + self.uri,
                         params={"JWT": self.token, "SubscriptionClient": clientId},


### PR DESCRIPTION

* Added support for new versions (v4.x+) of async_timeout module 
* Added backward compatibility code for async_timeout versions prior to 4.x

fixes #40 