### PR TITLE
Fix SSL deprecation, test assertion, and missing mypy dep

### DIFF
--- a/pyControl4/director.py
+++ b/pyControl4/director.py
@@ -54,7 +54,7 @@ class C4Director:
             yield self.session
         else:
             async with aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(verify_ssl=False)
+                connector=aiohttp.TCPConnector(ssl=False)
             ) as session:
                 yield session
 

--- a/pyControl4/websocket.py
+++ b/pyControl4/websocket.py
@@ -72,7 +72,7 @@ class _C4DirectorNamespace(socketio.AsyncClientNamespace):  # type: ignore[misc]
         if not self.connected and not self.subscription_id:
             _LOGGER.debug("Fetching subscriptionID from Control4")
             session = self.session or aiohttp.ClientSession(
-                connector=aiohttp.TCPConnector(verify_ssl=False)
+                connector=aiohttp.TCPConnector(ssl=False)
             )
             try:
                 async with asyncio.timeout(10):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,4 +4,5 @@ python-socketio-v4
 websocket-client
 pdoc3
 pytest-asyncio
+mypy
 types-xmltodict

--- a/tests/test_websocket_ssl.py
+++ b/tests/test_websocket_ssl.py
@@ -50,5 +50,5 @@ async def test_sio_connect_with_session():
             connector=mock_connector, connector_owner=False
         )
         mock_init.assert_called_once_with(
-            ssl_verify=False, http_session=mock_http_session
+            ssl_verify=True, http_session=mock_http_session
         )


### PR DESCRIPTION
## Summary
- Replace deprecated `aiohttp.TCPConnector(verify_ssl=False)` with `ssl=False` in `director.py` and `websocket.py` to eliminate `DeprecationWarning` on aiohttp 3.x (removed in 4.0)
- Fix `test_sio_connect_with_session` to assert `ssl_verify=True`, matching the production code from ee45410
- Add `mypy` to `requirements-dev.txt` — was stated as added in 25568bf but was missing from the file

## Test plan
- [x] All 34 existing tests pass
- [ ] Verify no `DeprecationWarning` from aiohttp in logs during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)