### PR TITLE
Fix test assertion for ssl_verify=True on session path

### DIFF
--- a/tests/test_websocket_ssl.py
+++ b/tests/test_websocket_ssl.py
@@ -50,5 +50,5 @@ async def test_sio_connect_with_session():
             connector=mock_connector, connector_owner=False
         )
         mock_init.assert_called_once_with(
-            ssl_verify=False, http_session=mock_http_session
+            ssl_verify=True, http_session=mock_http_session
         )


### PR DESCRIPTION
## Summary

- Fixes `test_sio_connect_with_session` which has been failing since commit `ee45410`

## Root cause

`ee45410` ("Change ssl_verify to True to prevent additional SSL context creation") intentionally changed `sio_connect()` to pass `ssl_verify=True` to `AsyncClient` when a caller-provided session is used. The rationale is that setting `ssl_verify=True` prevents engineio from creating its own no-verify `SSLContext`, allowing the connector's SSL configuration to take effect instead.

The test assertion on line 52 was never updated to match, so it continued expecting `ssl_verify=False` while the code now passes `ssl_verify=True`.

## Fix

Update the assertion in `test_sio_connect_with_session` to expect `ssl_verify=True`, matching the actual intended behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)